### PR TITLE
update xfce4-nofifyd.xml

### DIFF
--- a/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-notifyd.xml
+++ b/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-notifyd.xml
@@ -39,7 +39,6 @@
     </property>
     <property name="muted_applications" type="array">
       <value type="string" value="ca.desrt.dconf-editor"/>
-      <value type="string" value="notify-send"/>
     </property>
   </property>
   <property name="notify-location" type="uint" value="2"/>


### PR DESCRIPTION
Remove notify-send from list of muted applications by default.  Many scripts rely on notify-send being enabled to give user notifications.